### PR TITLE
Add approving messages (DEV-85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This release has a basic approval process for a single organization on board.
 
+- `ADD` Messages waiting for approval can be approved
 - `ADD` Message details can be viewed for approvals
 - `ADD` Message details can be viewed for my organization
 - `ADD` Rejected message can have a reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 This release has a basic approval process for a single organization on board.
 
 - `CNG` Redirects of actions on message refer to the detail view of that message
+- `ADD` Approved messages can have a note attached to them
 - `ADD` Messages waiting for approval can be approved
 - `ADD` Message details can be viewed for approvals
 - `ADD` Message details can be viewed for my organization
-- `ADD` Rejected message can have a reason
+- `ADD` Rejected messages can have a reason
 - `ADD` Messages waiting for approval can be rejected
 - `ADD` Dev script has a task to reset the task database
 - `ADD` Messages waiting for approval are listed in the approvals section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 This release has a basic approval process for a single organization on board.
 
+- `CNG` Redirects of actions on message refer to the detail view of that message
 - `ADD` Messages waiting for approval can be approved
 - `ADD` Message details can be viewed for approvals
 - `ADD` Message details can be viewed for my organization

--- a/lib/dealog_backoffice/messages/aggregates/message.ex
+++ b/lib/dealog_backoffice/messages/aggregates/message.ex
@@ -4,6 +4,7 @@ defmodule DealogBackoffice.Messages.Aggregates.Message do
     :title,
     :body,
     :status,
+    :approval_notes,
     :rejection_reasons
   ]
 
@@ -13,6 +14,7 @@ defmodule DealogBackoffice.Messages.Aggregates.Message do
     CreateMessage,
     ChangeMessage,
     SendMessageForApproval,
+    ApproveMessage,
     RejectMessage
   }
 
@@ -20,6 +22,7 @@ defmodule DealogBackoffice.Messages.Aggregates.Message do
     MessageCreated,
     MessageChanged,
     MessageSentForApproval,
+    MessageApproved,
     MessageRejected
   }
 
@@ -56,6 +59,17 @@ defmodule DealogBackoffice.Messages.Aggregates.Message do
       title: send.title,
       body: send.body,
       status: send.status
+    }
+  end
+
+  @doc """
+  Approve an existing message.
+  """
+  def execute(%Message{message_id: message_id}, %ApproveMessage{} = approve) do
+    %MessageApproved{
+      message_id: message_id,
+      status: approve.status,
+      note: approve.note
     }
   end
 
@@ -99,6 +113,15 @@ defmodule DealogBackoffice.Messages.Aggregates.Message do
         title: sent.title,
         body: sent.body,
         status: sent.status
+    }
+  end
+
+  def apply(%Message{} = message, %MessageApproved{} = approved) do
+    %Message{
+      message
+      | message_id: approved.message_id,
+        status: approved.status,
+        approval_notes: message.approval_notes || [] ++ [approved.note]
     }
   end
 

--- a/lib/dealog_backoffice/messages/commands/approve_message.ex
+++ b/lib/dealog_backoffice/messages/commands/approve_message.ex
@@ -1,0 +1,32 @@
+defmodule DealogBackoffice.Messages.Commands.ApproveMessage do
+  defstruct message_id: "",
+            status: :approved,
+            note: nil
+
+  use ExConstructor
+  use Vex.Struct
+
+  alias DealogBackoffice.Messages.Commands.ApproveMessage
+  alias DealogBackoffice.Messages.Projections.MessageForApproval
+
+  validates(:message_id, uuid: true)
+
+  validates(:status,
+    inclusion: [in: [:approved]]
+  )
+
+  def assign_message_id(%ApproveMessage{} = message, %MessageForApproval{id: message_id}) do
+    %ApproveMessage{message | message_id: message_id}
+  end
+
+  def set_status(%ApproveMessage{} = message) do
+    %ApproveMessage{message | status: :approved}
+  end
+
+  def maybe_set_note(%ApproveMessage{} = message, ""), do: message
+
+  def maybe_set_note(%ApproveMessage{} = message, note) do
+    %ApproveMessage{message | note: note}
+  end
+end
+

--- a/lib/dealog_backoffice/messages/events/message_approved.ex
+++ b/lib/dealog_backoffice/messages/events/message_approved.ex
@@ -1,0 +1,8 @@
+defmodule DealogBackoffice.Messages.Events.MessageApproved do
+  @derive Jason.Encoder
+  defstruct [
+    :message_id,
+    :status,
+    :note
+  ]
+end

--- a/lib/dealog_backoffice/messages/projections/message_for_approval.ex
+++ b/lib/dealog_backoffice/messages/projections/message_for_approval.ex
@@ -9,6 +9,7 @@ defmodule DealogBackoffice.Messages.Projections.MessageForApproval do
     field :body, :string
     field :status, :string
     field :reason, :string
+    field :note, :string
 
     timestamps()
   end

--- a/lib/dealog_backoffice/messages/projectors/message.ex
+++ b/lib/dealog_backoffice/messages/projectors/message.ex
@@ -8,6 +8,7 @@ defmodule DealogBackoffice.Messages.Projectors.Message do
     MessageCreated,
     MessageChanged,
     MessageSentForApproval,
+    MessageApproved,
     MessageRejected
   }
 
@@ -41,6 +42,13 @@ defmodule DealogBackoffice.Messages.Projectors.Message do
       title: sent_for_approval.title,
       body: sent_for_approval.body,
       status: sent_for_approval.status,
+      updated_at: metadata.created_at
+    )
+  end)
+
+  project(%MessageApproved{} = approved, metadata, fn multi ->
+    update_message(multi, approved.message_id,
+      status: approved.status,
       updated_at: metadata.created_at
     )
   end)

--- a/lib/dealog_backoffice/messages/projectors/message_approval.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_approval.ex
@@ -4,7 +4,12 @@ defmodule DealogBackoffice.Messages.Projectors.MessageApproval do
     name: "Messages.Projectors.MessageApproval",
     consistency: :strong
 
-  alias DealogBackoffice.Messages.Events.{MessageSentForApproval, MessageRejected}
+  alias DealogBackoffice.Messages.Events.{
+    MessageSentForApproval,
+    MessageApproved,
+    MessageRejected
+  }
+
   alias DealogBackoffice.Messages.Projections.MessageForApproval
   alias DealogBackoffice.Messages
 
@@ -21,6 +26,14 @@ defmodule DealogBackoffice.Messages.Projectors.MessageApproval do
       {:error, _} ->
         create_message_approval(multi, sent, metadata)
     end
+  end)
+
+  project(%MessageApproved{} = approved, metadata, fn multi ->
+    update_message_approval(multi, approved.message_id,
+      status: approved.status,
+      note: approved.note,
+      updated_at: metadata.created_at
+    )
   end)
 
   project(%MessageRejected{} = rejected, metadata, fn multi ->

--- a/lib/dealog_backoffice/router.ex
+++ b/lib/dealog_backoffice/router.ex
@@ -12,6 +12,7 @@ defmodule DealogBackoffice.Router do
     CreateMessage,
     ChangeMessage,
     SendMessageForApproval,
+    ApproveMessage,
     RejectMessage
   }
 
@@ -21,5 +22,5 @@ defmodule DealogBackoffice.Router do
 
   identify(Message, by: :message_id, prefix: "message-")
 
-  dispatch([CreateMessage, ChangeMessage, SendMessageForApproval, RejectMessage], to: Message)
+  dispatch([CreateMessage, ChangeMessage, SendMessageForApproval, ApproveMessage, RejectMessage], to: Message)
 end

--- a/lib/dealog_backoffice_web/live/message_approvals/edit.ex
+++ b/lib/dealog_backoffice_web/live/message_approvals/edit.ex
@@ -17,6 +17,18 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.Edit do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
+  defp apply_action(socket, :approve, %{"id" => id}) do
+    case Messages.get_message_for_approval(id) do
+      {:ok, message} ->
+        assign(socket,
+          title: gettext("Approve message"),
+          active_page: :approvals,
+          message: message,
+          note: nil
+        )
+    end
+  end
+
   defp apply_action(socket, :reject, %{"id" => id}) do
     case Messages.get_message_for_approval(id) do
       {:ok, message} ->

--- a/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
@@ -1,19 +1,40 @@
 <section>
-  <%= if @live_action == :reject do %>
-  <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:leading-9 sm:truncate">
-    <%= gettext "Message rejection" %>
-  </h1>
-  <p class="mt-4">
-    <%= gettext "Add a note of why the message is rejected. This message will be shown to the editor." %>
-  </p>
+  <%= if @live_action == :approve do %>
+    <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:leading-9 sm:truncate">
+      <%= gettext "Message approval" %>
+    </h1>
+    <p class="mt-4">
+      <%= gettext "If a note is added it will be displayed to the person publishing the message." %>
+    </p>
+    <%=
+      live_component @socket,
+        DealogBackofficeWeb.MessageApprovalsLive.FormComponent,
+        id: @message.id,
+        action: @live_action,
+        message: @message,
+        text: @note,
+        return_to: Routes.approvals_path(@socket, :index),
+        label_text_field: gettext("Note"),
+        label_submit_button: gettext("Send note")
+    %>
   <% end %>
-  <%=
-    live_component @socket,
-      DealogBackofficeWeb.MessageApprovalsLive.FormComponent,
-      id: @message.id,
-      action: @live_action,
-      message: @message,
-      reason: @reason,
-      return_to: Routes.approvals_path(@socket, :index)
-  %>
+  <%= if @live_action == :reject do %>
+    <h1 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:leading-9 sm:truncate">
+      <%= gettext "Message rejection" %>
+    </h1>
+    <p class="mt-4">
+      <%= gettext "Add a note of why the message is rejected. This message will be shown to the editor." %>
+    </p>
+    <%=
+      live_component @socket,
+        DealogBackofficeWeb.MessageApprovalsLive.FormComponent,
+        id: @message.id,
+        action: @live_action,
+        message: @message,
+        text: @reason,
+        return_to: Routes.approvals_path(@socket, :index),
+        label_text_field: gettext("Reason"),
+        label_submit_button: gettext("Send reason")
+    %>
+  <% end %>
 </section>

--- a/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
@@ -13,7 +13,7 @@
         action: @live_action,
         message: @message,
         text: @note,
-        return_to: Routes.approvals_path(@socket, :index),
+        return_to: Routes.approvals_path(@socket, :show, @message),
         label_text_field: gettext("Note"),
         label_submit_button: gettext("Send note")
     %>
@@ -32,7 +32,7 @@
         action: @live_action,
         message: @message,
         text: @reason,
-        return_to: Routes.approvals_path(@socket, :index),
+        return_to: Routes.approvals_path(@socket, :show, @message),
         label_text_field: gettext("Reason"),
         label_submit_button: gettext("Send reason")
     %>

--- a/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/edit.html.leex
@@ -15,7 +15,7 @@
         text: @note,
         return_to: Routes.approvals_path(@socket, :show, @message),
         label_text_field: gettext("Note"),
-        label_submit_button: gettext("Send note")
+        label_submit_button: gettext("Attach note and approve")
     %>
   <% end %>
   <%= if @live_action == :reject do %>
@@ -34,7 +34,7 @@
         text: @reason,
         return_to: Routes.approvals_path(@socket, :show, @message),
         label_text_field: gettext("Reason"),
-        label_submit_button: gettext("Send reason")
+        label_submit_button: gettext("Attach reason and reject")
     %>
   <% end %>
 </section>

--- a/lib/dealog_backoffice_web/live/message_approvals/form_component.ex
+++ b/lib/dealog_backoffice_web/live/message_approvals/form_component.ex
@@ -4,22 +4,36 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.FormComponent do
   alias DealogBackoffice.Messages
 
   @impl true
-  def update(%{message: message, reason: reason} = assigns, socket) do
+  def update(%{message: message, text: text} = assigns, socket) do
     socket =
       socket
       |> assign(assigns)
       |> assign(message: message)
-      |> assign(reason: reason)
+      |> assign(text: text)
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_event("save_reason", %{"message" => message_params}, socket) do
+  def handle_event("save", %{"message" => message_params}, socket) do
     {:noreply, save_message(socket, socket.assigns.action, message_params)}
   end
 
-  defp save_message(socket, :reject, %{"id" => id, "reason" => reason}) do
+  defp save_message(socket, :approve, %{"id" => id, "text" => note}) do
+    {:ok, message} = Messages.get_message_for_approval(id)
+
+    case Messages.approve_message(message, note) do
+      {:ok, message} ->
+        socket
+        |> put_flash(
+          :save_success,
+          gettext("Message %{title} approved", title: message.title)
+        )
+        |> push_redirect(to: socket.assigns.return_to)
+    end
+  end
+
+  defp save_message(socket, :reject, %{"id" => id, "text" => reason}) do
     {:ok, message} = Messages.get_message_for_approval(id)
 
     case Messages.reject_message(message, reason) do

--- a/lib/dealog_backoffice_web/live/message_approvals/form_component.ex
+++ b/lib/dealog_backoffice_web/live/message_approvals/form_component.ex
@@ -16,10 +16,10 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.FormComponent do
 
   @impl true
   def handle_event("save", %{"message" => message_params}, socket) do
-    {:noreply, save_message(socket, socket.assigns.action, message_params)}
+    {:noreply, apply_action(socket, socket.assigns.action, message_params)}
   end
 
-  defp save_message(socket, :approve, %{"id" => id, "text" => note}) do
+  defp apply_action(socket, :approve, %{"id" => id, "text" => note}) do
     {:ok, message} = Messages.get_message_for_approval(id)
 
     case Messages.approve_message(message, note) do
@@ -33,7 +33,7 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.FormComponent do
     end
   end
 
-  defp save_message(socket, :reject, %{"id" => id, "text" => reason}) do
+  defp apply_action(socket, :reject, %{"id" => id, "text" => reason}) do
     {:ok, message} = Messages.get_message_for_approval(id)
 
     case Messages.reject_message(message, reason) do

--- a/lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex
@@ -1,13 +1,13 @@
 <%
   errors = if assigns[:errors], do: @errors, else: %{}
   # TODO Move this somewhere else. Maybe to the live view.
-  fields_with_labels = [reason: gettext("Reason")]
+  fields_with_labels = [text: @label_text_field]
 %>
 <%= 
   f = form_for :message, "#",
     errors: errors, 
     phx_target: @myself,
-    phx_submit: "save_reason"
+    phx_submit: "save"
 %>
   <%= if assigns[:error] do %>
     <div class="mt-4">
@@ -29,24 +29,24 @@
     <div class="mt-2">
       <%=
         label f,
-          gettext("Reason")
+          @label_text_field
       %>
       <%=
-        textarea f, :reason,
-          value: @reason,
+        textarea f, :text,
+          value: @text,
           rows: 10,
-          class: "form-input flex-1 block w-full px-3 py-2 rounded-md sm:text-sm sm:leading-5#{if has_errors?(f, :reason), do: " border-red-700"}"
+          class: "form-input flex-1 block w-full px-3 py-2 rounded-md sm:text-sm sm:leading-5#{if has_errors?(f, :text), do: " border-red-700"}"
       %>
       <%=
         errors_for_field f,
-          :reason,
-          class: if has_errors?(f, :reason), do: "text-red-700", else: ""
+          :text,
+          class: if has_errors?(f, :text), do: "text-red-700", else: ""
       %>
     </div>
     <div class="mt-4 flex justify-end">
       <span class="ml-3 inline-flex rounded-md shadow-sm">
         <%=
-          submit gettext("Send reason"),
+          submit @label_submit_button,
           class: "inline-flex justify-center py-2 px-4 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-yellow-600 hover:bg-yellow-500 focus:outline-none focus:border-yellow-700 focus:shadow-outline-gray active:bg-yellow-700 transition duration-150 ease-in-out"
         %>
       </span>

--- a/lib/dealog_backoffice_web/live/message_approvals/index.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/index.html.leex
@@ -32,6 +32,7 @@
                   "waiting_for_approval" -> "text-yellow-800 bg-yellow-200"
                   "approved" -> "bg-green-600 text-green-200"
                   "rejected" -> "bg-red-600 text-red-200"
+                  _ -> "bg-black text-white"
                 end
               %>
               <tr class="<%= if is_even?(index), do: "bg-gray-100" %>">

--- a/lib/dealog_backoffice_web/live/message_approvals/index.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/index.html.leex
@@ -14,7 +14,7 @@
               <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
                 <%= gettext "Title" %>
               </th>
-              <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+              <th class="px-6 py-3 bg-gray-50 text-center text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
                 <%= gettext "Status" %>
               </th>
               <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
@@ -49,7 +49,7 @@
                     </div>
                   </a>
                 </td>
-                <td class="px-6 py-4 whitespace-no-wrap text-sm leading-5 text-gray-500">
+                <td class="px-6 py-4 whitespace-no-wrap text-center text-sm leading-5 text-gray-500">
                   <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium leading-4 <%= status_colors %>">
                     <%= Gettext.gettext(DealogBackofficeWeb.Gettext, message.status) %>
                   </span>
@@ -60,7 +60,7 @@
                       <%= display_date_time(message.inserted_at) %>
                     </div>
                     <div class="text-xs">
-                      <%= display_date_time_relative(message.updated_at) %>
+                      <%= gettext "last changed" %> <%= display_date_time_relative(message.updated_at) %>
                     </div>
                   </div>
                 </td>

--- a/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
@@ -193,6 +193,15 @@
           <%= if @message.status == "waiting_for_approval" do %>
             <div>
               <a
+                href="<%= Routes.approvals_path(@socket, :approve, @message) %>"
+                class="mt-1 group w-full flex items-center px-2 py-2 text-sm leading-5 font-medium rounded-md bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
+                <%= gettext "Approve" %>
+              </a>
+            </div>
+          <% end %>
+          <%= if @message.status == "waiting_for_approval" do %>
+            <div>
+              <a
                 href="<%= Routes.approvals_path(@socket, :reject, @message) %>"
                 class="mt-1 group w-full flex items-center px-2 py-2 text-sm leading-5 font-medium rounded-md bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition ease-in-out duration-150">
                 <%= gettext "Reject" %>

--- a/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
@@ -3,6 +3,7 @@
   status_colors = case @message.status do
     "waiting_for_approval" -> "text-yellow-800 bg-yellow-200"
     "draft" -> "bg-gray-600 text-gray-200"
+    "approved" -> "bg-green-600 text-green-200"
     "rejected" -> "bg-red-600 text-red-200"
     _ -> "bg-black text-white"
   end

--- a/lib/dealog_backoffice_web/live/organization_messages/edit.ex
+++ b/lib/dealog_backoffice_web/live/organization_messages/edit.ex
@@ -31,7 +31,7 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.Edit do
             title: message.title
           )
         )
-        |> push_redirect(to: Routes.organization_messages_path(socket, :index))
+        |> push_redirect(to: Routes.organization_messages_path(socket, :show, message.id))
 
       {:ok, message} ->
         assign(socket,
@@ -55,7 +55,9 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.Edit do
             title: original_message.title
           )
         )
-        |> push_redirect(to: Routes.organization_messages_path(socket, :index))
+        |> push_redirect(
+          to: Routes.organization_messages_path(socket, :show, original_message.id)
+        )
 
       {:ok, message} ->
         socket

--- a/lib/dealog_backoffice_web/live/organization_messages/edit.ex
+++ b/lib/dealog_backoffice_web/live/organization_messages/edit.ex
@@ -65,7 +65,7 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.Edit do
           :save_success,
           gettext("Message %{title} successfully sent for approval", title: message.title)
         )
-        |> push_redirect(to: Routes.organization_messages_path(socket, :index))
+        |> push_redirect(to: Routes.organization_messages_path(socket, :show, message.id))
     end
   end
 end

--- a/lib/dealog_backoffice_web/live/organization_messages/edit.html.leex
+++ b/lib/dealog_backoffice_web/live/organization_messages/edit.html.leex
@@ -25,6 +25,6 @@
       id: @message.id || :new,
       action: @live_action,
       message: @message,
-      return_to: Routes.organization_messages_path(@socket, :index)
+      return_to: Routes.organization_messages_path(@socket, :show, @message.id || "")
   %>
 </section>

--- a/lib/dealog_backoffice_web/live/organization_messages/form_component.ex
+++ b/lib/dealog_backoffice_web/live/organization_messages/form_component.ex
@@ -15,10 +15,10 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.FormComponent do
 
   @impl true
   def handle_event("save_message", %{"message" => message_params}, socket) do
-    {:noreply, save_message(socket, socket.assigns.action, message_params)}
+    {:noreply, apply_action(socket, socket.assigns.action, message_params)}
   end
 
-  defp save_message(socket, :new, message_params) do
+  defp apply_action(socket, :new, message_params) do
     case Messages.create_message(message_params) do
       {:error, {:validation_failure, errors}} ->
         assign(socket, error: true, errors: errors, message: convert(message_params))
@@ -33,7 +33,7 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.FormComponent do
     end
   end
 
-  defp save_message(socket, :change, message_params) do
+  defp apply_action(socket, :change, message_params) do
     # TODO Move to change_message function to keep API clean
     {:ok, original_message} =
       message_params

--- a/lib/dealog_backoffice_web/live/organization_messages/form_component.ex
+++ b/lib/dealog_backoffice_web/live/organization_messages/form_component.ex
@@ -29,7 +29,7 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.FormComponent do
           :save_success,
           gettext("Message %{title} created successfully", title: message.title)
         )
-        |> push_redirect(to: socket.assigns.return_to)
+        |> push_redirect(to: socket.assigns.return_to <> message.id)
     end
   end
 

--- a/lib/dealog_backoffice_web/live/organization_messages/index.html.leex
+++ b/lib/dealog_backoffice_web/live/organization_messages/index.html.leex
@@ -32,6 +32,7 @@
                   "waiting_for_approval" -> "text-yellow-800 bg-yellow-200"
                   "draft" -> "bg-gray-600 text-gray-200"
                   "rejected" -> "bg-red-600 text-red-200"
+                  "approved" -> "bg-green-600 text-green-200"
                   _ -> "bg-black text-white"
                 end
               %>

--- a/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
+++ b/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
@@ -200,7 +200,7 @@
               </a>
             </div>
           <% end %>
-          <%= unless @message.status == "waiting_for_approval" do %>
+          <%= if @message.status in ["draft"] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :send_for_approval, @message) %>"

--- a/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
+++ b/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
@@ -3,6 +3,7 @@
   status_colors = case @message.status do
     "waiting_for_approval" -> "text-yellow-800 bg-yellow-200"
     "draft" -> "bg-gray-600 text-gray-200"
+    "approved" -> "bg-green-600 text-green-200"
     "rejected" -> "bg-red-600 text-red-200"
     _ -> "bg-black text-white"
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -386,7 +386,7 @@ msgid "Author"
 msgstr "Autor"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:198
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:199
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -398,8 +398,8 @@ msgstr "Metadaten"
 
 #, elixir-format
 #: lib/dealog_backoffice_web/live/message_approvals/index.html.leex:18
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:107 lib/dealog_backoffice_web/live/organization_messages/index.html.leex:18
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:107
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:108 lib/dealog_backoffice_web/live/organization_messages/index.html.leex:18
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:108
 msgid "Status"
 msgstr "Status"
 
@@ -446,12 +446,12 @@ msgid "Message %{title} changed successfully"
 msgstr "Meldung %{title} erfolgreich geändert"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:64
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:66
 msgid "Message %{title} successfully sent for approval"
 msgstr "Meldung %{title} erfolgreich zur Freigabe geschickt"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:207
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:208
 msgid "Send for approval"
 msgstr "Zur Freigabe schicken"
 
@@ -461,7 +461,7 @@ msgid "All messages waiting for approval are listed here."
 msgstr "Alle Meldungen, die auf Freigabe warten, sind hier aufgelistet."
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:207
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:208
 msgid "Reject"
 msgstr "Zurückweisen"
 
@@ -521,37 +521,32 @@ msgid "Reject message"
 msgstr "Meldung zurückweisen"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
-msgid "Send reason"
-msgstr "Grund senden"
-
-#, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:190
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:190
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:191
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:191
 msgid "Back to overview"
 msgstr "Zurück zur Übersicht"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:35
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:35
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:36
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:36
 msgid "Body"
 msgstr "Meldungstext"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:91
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:91
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:92
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:92
 msgid "Created at"
 msgstr "Erstellt um"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:28
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:28
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:29
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:29
 msgid "Date of message"
 msgstr "Datum der Meldung"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:99
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:99
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:100
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:100
 msgid "Last changed at"
 msgstr "Zuletzt geändert um"
 
@@ -562,20 +557,20 @@ msgid "Message %{id} could not be found"
 msgstr "Meldung %{id} konnte nicht gefunden werden"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:83
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:83
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:84
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:84
 msgid "Message ID"
 msgstr "Meldungsnummer"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:117
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:117
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:118
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:118
 msgid "Message history"
 msgstr "Meldungshistorie"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:57
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:57
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:58
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:58
 msgid "Message information"
 msgstr "Meldungsinformationen"
 
@@ -585,27 +580,28 @@ msgid "Message not found!"
 msgstr "Meldung nich gefunden!"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:20
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:20
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:21
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:21
 msgid "Message status"
 msgstr "Meldungsstatus"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:131
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:144 lib/dealog_backoffice_web/live/message_approvals/show.html.leex:157
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:171 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:131
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:144 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:157
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:171
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:132
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:145 lib/dealog_backoffice_web/live/message_approvals/show.html.leex:158
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:172 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:132
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:145 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:158
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:172
 msgid "by"
 msgstr "von"
 
 #, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/index.html.leex:63
 #: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:65
 msgid "last changed"
 msgstr "zuletzt geändert"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:199
 msgid "Approve"
 msgstr "Freigeben"
 
@@ -636,5 +632,10 @@ msgstr "Notiz"
 
 #, elixir-format
 #: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:18
-msgid "Send note"
-msgstr "Notiz anhängen"
+msgid "Attach note and approve"
+msgstr "Notiz anhängen und freigeben"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
+msgid "Attach reason and reject"
+msgstr "Grund speichern und zurückweisen"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -17,6 +17,9 @@ msgstr "Entwurf"
 msgid "waiting_for_approval"
 msgstr "Warten auf Freigabe"
 
+msgid "approved"
+msgstr "Freigegeben"
+
 msgid "rejected"
 msgstr "Zurückgewiesen"
 
@@ -458,7 +461,7 @@ msgid "All messages waiting for approval are listed here."
 msgstr "Alle Meldungen, die auf Freigabe warten, sind hier aufgelistet."
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:207
 msgid "Reject"
 msgstr "Zurückweisen"
 
@@ -493,33 +496,32 @@ msgid "There was an error!"
 msgstr "Ein Fehler ist aufgetreten!"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:7
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:26
 msgid "Add a note of why the message is rejected. This message will be shown to the editor."
 msgstr "Bitte einen Hinweis, warum die Meldung zurückgewiesen wurde. Dieser wird der bearbeitenden Person angezeigt werden."
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:30
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:44
 msgid "Message %{title} rejected"
 msgstr "Meldung %{title} erfolgreich erstellt"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:4
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:23
 msgid "Message rejection"
 msgstr "Meldungszurückweisung"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:4
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:32
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:36
 msgid "Reason"
 msgstr "Grund"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:24
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:36
 msgid "Reject message"
 msgstr "Meldung zurückweisen"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:49
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
 msgid "Send reason"
 msgstr "Grund senden"
 
@@ -598,6 +600,41 @@ msgid "by"
 msgstr "von"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:64
+#: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:65
 msgid "last changed"
 msgstr "zuletzt geändert"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+msgid "Approve"
+msgstr "Freigeben"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:24
+msgid "Approve message"
+msgstr "Meldung freigeben"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:7
+msgid "If a note is added it will be displayed to the person publishing the message."
+msgstr "Wenn eine Notiz hinzugefügt wird, wird diese der Person, welche die Meldung veröffentlicht, angezeigt."
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:30
+msgid "Message %{title} approved"
+msgstr "Meldung %{title} erfolgreich freigegeben"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:4
+msgid "Message approval"
+msgstr "Meldungsfreigabe"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:17
+msgid "Note"
+msgstr "Notiz"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:18
+msgid "Send note"
+msgstr "Notiz anhängen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -16,6 +16,9 @@ msgstr "Draft"
 msgid "waiting_for_approval"
 msgstr "Waiting for approval"
 
+msgid "approved"
+msgstr "Approved"
+
 msgid "rejected"
 msgstr "Rejected"
 
@@ -457,7 +460,7 @@ msgid "All messages waiting for approval are listed here."
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:207
 msgid "Reject"
 msgstr ""
 
@@ -492,33 +495,32 @@ msgid "There was an error!"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:7
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:26
 msgid "Add a note of why the message is rejected. This message will be shown to the editor."
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:30
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:44
 msgid "Message %{title} rejected"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:4
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:23
 msgid "Message rejection"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:4
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:32
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:36
 msgid "Reason"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:24
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:36
 msgid "Reject message"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.html.leex:49
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
 msgid "Send reason"
 msgstr ""
 
@@ -597,6 +599,41 @@ msgid "by"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:64
+#: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:65
 msgid "last changed"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+msgid "Approve"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:24
+msgid "Approve message"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:7
+msgid "If a note is added it will be displayed to the person publishing the message."
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:30
+msgid "Message %{title} approved"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:4
+msgid "Message approval"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:17
+msgid "Note"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:18
+msgid "Send note"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -385,7 +385,7 @@ msgid "Author"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:198
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:199
 msgid "Edit"
 msgstr ""
 
@@ -397,8 +397,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/dealog_backoffice_web/live/message_approvals/index.html.leex:18
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:107 lib/dealog_backoffice_web/live/organization_messages/index.html.leex:18
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:107
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:108 lib/dealog_backoffice_web/live/organization_messages/index.html.leex:18
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:108
 msgid "Status"
 msgstr ""
 
@@ -445,12 +445,12 @@ msgid "Message %{title} changed successfully"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:64
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:66
 msgid "Message %{title} successfully sent for approval"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:207
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:208
 msgid "Send for approval"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgid "All messages waiting for approval are listed here."
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:207
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:208
 msgid "Reject"
 msgstr ""
 
@@ -520,37 +520,32 @@ msgid "Reject message"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
-msgid "Send reason"
-msgstr ""
-
-#, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:190
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:190
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:191
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:191
 msgid "Back to overview"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:35
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:35
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:36
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:36
 msgid "Body"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:91
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:91
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:92
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:92
 msgid "Created at"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:28
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:28
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:29
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:29
 msgid "Date of message"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:99
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:99
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:100
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:100
 msgid "Last changed at"
 msgstr ""
 
@@ -561,20 +556,20 @@ msgid "Message %{id} could not be found"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:83
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:83
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:84
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:84
 msgid "Message ID"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:117
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:117
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:118
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:118
 msgid "Message history"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:57
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:57
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:58
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:58
 msgid "Message information"
 msgstr ""
 
@@ -584,27 +579,28 @@ msgid "Message not found!"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:20
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:20
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:21
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:21
 msgid "Message status"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:131
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:144 lib/dealog_backoffice_web/live/message_approvals/show.html.leex:157
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:171 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:131
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:144 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:157
-#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:171
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:132
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:145 lib/dealog_backoffice_web/live/message_approvals/show.html.leex:158
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:172 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:132
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:145 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:158
+#: lib/dealog_backoffice_web/live/organization_messages/show.html.leex:172
 msgid "by"
 msgstr ""
 
 #, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/index.html.leex:63
 #: lib/dealog_backoffice_web/live/organization_messages/index.html.leex:65
 msgid "last changed"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:198
+#: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:199
 msgid "Approve"
 msgstr ""
 
@@ -635,5 +631,10 @@ msgstr ""
 
 #, elixir-format
 #: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:18
-msgid "Send note"
+msgid "Attach note and approve"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/message_approvals/edit.html.leex:37
+msgid "Attach reason and reject"
 msgstr ""

--- a/priv/repo/migrations/20200902113604_add_approval_note_to_message_approvals_projection.exs
+++ b/priv/repo/migrations/20200902113604_add_approval_note_to_message_approvals_projection.exs
@@ -1,0 +1,9 @@
+defmodule DealogBackoffice.Repo.Migrations.AddApprovalNoteToMessageApprovalsProjection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:message_approvals) do
+      add :note, :text
+    end
+  end
+end

--- a/test/dealog_backoffice/messages/aggregates/message_test.exs
+++ b/test/dealog_backoffice/messages/aggregates/message_test.exs
@@ -1,8 +1,21 @@
 defmodule DealogBackoffice.Messages.Aggregates.MessageTest do
   use DealogBackoffice.AggregateCase, aggregate: DealogBackoffice.Messages.Aggregates.Message
 
-  alias DealogBackoffice.Messages.Commands.{CreateMessage, ChangeMessage, SendMessageForApproval}
-  alias DealogBackoffice.Messages.Events.{MessageCreated, MessageChanged, MessageSentForApproval}
+  alias DealogBackoffice.Messages.Commands.{
+    CreateMessage,
+    ChangeMessage,
+    SendMessageForApproval,
+    ApproveMessage,
+    RejectMessage
+  }
+
+  alias DealogBackoffice.Messages.Events.{
+    MessageCreated,
+    MessageChanged,
+    MessageSentForApproval,
+    MessageApproved,
+    MessageRejected
+  }
 
   describe "create message" do
     @tag :unit
@@ -70,16 +83,148 @@ defmodule DealogBackoffice.Messages.Aggregates.MessageTest do
         ],
         struct(SendMessageForApproval, %{
           message_id: message_id,
-          title: "A changed title",
-          body: "A changed body",
+          title: "A title",
+          body: "A body",
           status: :waiting_for_approval
         }),
         [
           %MessageSentForApproval{
             message_id: message_id,
             status: :waiting_for_approval,
-            title: "A changed title",
-            body: "A changed body"
+            title: "A title",
+            body: "A body"
+          }
+        ]
+      )
+    end
+  end
+
+  describe "approve message" do
+    @tag :unit
+    test "should successfully be rejected without note" do
+      message_id = UUID.uuid4()
+
+      assert_events(
+        [
+          %MessageCreated{
+            message_id: message_id,
+            status: :draft,
+            title: "A title",
+            body: "A body"
+          },
+          %MessageSentForApproval{
+            message_id: message_id,
+            status: :waiting_for_approval,
+            title: "A title",
+            body: "A body"
+          }
+        ],
+        struct(ApproveMessage, %{
+          message_id: message_id
+        }),
+        [
+          %MessageApproved{
+            message_id: message_id,
+            status: :approved
+          }
+        ]
+      )
+    end
+
+    @tag :unit
+    test "should successfully be approved with a note" do
+      message_id = UUID.uuid4()
+
+      assert_events(
+        [
+          %MessageCreated{
+            message_id: message_id,
+            status: :draft,
+            title: "A title",
+            body: "A body"
+          },
+          %MessageSentForApproval{
+            message_id: message_id,
+            status: :waiting_for_approval,
+            title: "A title",
+            body: "A body"
+          }
+        ],
+        struct(ApproveMessage, %{
+          message_id: message_id,
+          note: "A note"
+        }),
+        [
+          %MessageApproved{
+            message_id: message_id,
+            status: :approved,
+            note: "A note"
+          }
+        ]
+      )
+    end
+  end
+
+  describe "reject message" do
+    @tag :unit
+    test "should successfully be rejected without reason" do
+      message_id = UUID.uuid4()
+
+      assert_events(
+        [
+          %MessageCreated{
+            message_id: message_id,
+            status: :draft,
+            title: "A title",
+            body: "A body"
+          },
+          %MessageSentForApproval{
+            message_id: message_id,
+            status: :waiting_for_approval,
+            title: "A title",
+            body: "A body"
+          }
+        ],
+        struct(RejectMessage, %{
+          message_id: message_id
+        }),
+        [
+          %MessageRejected{
+            message_id: message_id,
+            status: :rejected
+          }
+        ]
+      )
+    end
+
+    @tag :unit
+    test "should successfully be rejected with reason" do
+      message_id = UUID.uuid4()
+
+      assert_events(
+        [
+          %MessageCreated{
+            message_id: message_id,
+            status: :draft,
+            title: "A title",
+            body: "A body"
+          },
+          %MessageSentForApproval{
+            message_id: message_id,
+            status: :waiting_for_approval,
+            title: "A title",
+            body: "A body"
+          }
+        ],
+        struct(RejectMessage, %{
+          message_id: message_id,
+          reason: "A reason"
+        }),
+        [
+          %MessageRejected{
+            message_id: message_id,
+            status: :rejected,
+            reason: "A reason"
           }
         ]
       )

--- a/test/dealog_backoffice_web/live/message_approvals/edit_test.exs
+++ b/test/dealog_backoffice_web/live/message_approvals/edit_test.exs
@@ -1,9 +1,45 @@
-defmodule DealogBackofficeWeb.MessageApprovalsLive.MessageTest do
+defmodule DealogBackofficeWeb.MessageApprovalsLive.EditTest do
   use DealogBackofficeWeb.ConnCase
 
   import Phoenix.LiveViewTest
 
   alias DealogBackoffice.Messages
+
+  describe "Approve message" do
+    setup [:prepare_message_for_approval]
+
+    test "should render form", %{conn: conn, message_for_approval: message_for_approval} do
+      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
+      rendered = render(view)
+      assert rendered =~ "Note"
+      assert rendered =~ "Message approval"
+    end
+
+    #    test "should approve a message", %{conn: conn, message_for_approval: message_for_approval} do
+    #      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
+    #
+    #      result =
+    #        view
+    #        |> element("form")
+    #        |> render_submit(%{message: %{note: ""}})
+    #
+    #      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
+    #    end
+    #
+    #    test "should approve a message with a note", %{
+    #      conn: conn,
+    #      message_for_approval: message_for_approval
+    #    } do
+    #      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
+    #
+    #      result =
+    #        view
+    #        |> element("form")
+    #        |> render_submit(%{message: %{note: "A note"}})
+    #
+    #      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
+    #    end
+  end
 
   describe "Reject message" do
     setup [:prepare_message_for_approval]

--- a/test/dealog_backoffice_web/live/message_approvals/edit_test.exs
+++ b/test/dealog_backoffice_web/live/message_approvals/edit_test.exs
@@ -15,30 +15,32 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.EditTest do
       assert rendered =~ "Message approval"
     end
 
-    #    test "should approve a message", %{conn: conn, message_for_approval: message_for_approval} do
-    #      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
-    #
-    #      result =
-    #        view
-    #        |> element("form")
-    #        |> render_submit(%{message: %{note: ""}})
-    #
-    #      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
-    #    end
-    #
-    #    test "should approve a message with a note", %{
-    #      conn: conn,
-    #      message_for_approval: message_for_approval
-    #    } do
-    #      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
-    #
-    #      result =
-    #        view
-    #        |> element("form")
-    #        |> render_submit(%{message: %{note: "A note"}})
-    #
-    #      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
-    #    end
+    test "should approve a message", %{conn: conn, message_for_approval: message_for_approval} do
+      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
+
+      result =
+        view
+        |> element("form")
+        |> render_submit(%{message: %{note: ""}})
+
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path == "/approvals/#{message_for_approval.id}"
+    end
+
+    test "should approve a message with a note", %{
+      conn: conn,
+      message_for_approval: message_for_approval
+    } do
+      {:ok, view, _} = live(conn, "/approvals/#{message_for_approval.id}/approve")
+
+      result =
+        view
+        |> element("form")
+        |> render_submit(%{message: %{note: "A note"}})
+
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path == "/approvals/#{message_for_approval.id}"
+    end
   end
 
   describe "Reject message" do
@@ -59,7 +61,8 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.EditTest do
         |> element("form")
         |> render_submit(%{message: %{reason: ""}})
 
-      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path == "/approvals/#{message_for_approval.id}"
     end
 
     test "should reject a message with a reason", %{
@@ -73,7 +76,8 @@ defmodule DealogBackofficeWeb.MessageApprovalsLive.EditTest do
         |> element("form")
         |> render_submit(%{message: %{reason: "A reason"}})
 
-      assert {_, {:live_redirect, %{to: "/approvals"}}} = result
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path == "/approvals/#{message_for_approval.id}"
     end
   end
 

--- a/test/dealog_backoffice_web/live/organization_messages/edit_test.exs
+++ b/test/dealog_backoffice_web/live/organization_messages/edit_test.exs
@@ -28,7 +28,8 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.EditTest do
         |> element("form")
         |> render_submit(%{message: %{title: "A title", body: "A body"}})
 
-      assert {_, {:live_redirect, %{to: "/organization-messages"}}} = result
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path =~ "/organization-messages"
     end
   end
 
@@ -51,7 +52,8 @@ defmodule DealogBackofficeWeb.OrganizationMessagesLive.EditTest do
         |> element("form")
         |> render_submit(%{message: %{title: "A changed title", body: "A change body"}})
 
-      assert {_, {:live_redirect, %{to: "/organization-messages"}}} = result
+      assert {_, {:live_redirect, %{to: redirect_path}}} = result
+      assert redirect_path == "/organization-messages/#{message.id}"
     end
   end
 

--- a/test/dealog_backoffice_web/live/organization_messages/edit_test.exs
+++ b/test/dealog_backoffice_web/live/organization_messages/edit_test.exs
@@ -1,4 +1,4 @@
-defmodule DealogBackofficeWeb.OrganizationMessagesLive.MessageLiveTest do
+defmodule DealogBackofficeWeb.OrganizationMessagesLive.EditTest do
   use DealogBackofficeWeb.ConnCase
 
   import Phoenix.LiveViewTest


### PR DESCRIPTION
### Main objective
This PR contributes by adding the approval of messages waiting for approval. Additionally there can be a note attached which  will be displayed on the detail page.

### Additional changes
Further changes are that the redirect after creation, edit, send for approval on the my organization section as well as after approval, rejection is the respective detail page instead of the listing page. This enhances keeping the context better.

Also the wording is slightly changed for approval and rejection form pages.

### Todos

- [x] Implement approving a message in the correct state
- [x] Implement adding an additional note
- [x] Add tests
- [x] Update translations
- [x] Add to changelog
- [x] Change redirect for my organization actions
- [x] Change redirect for approvals actions
- [x] Adapt wording when approving or rejecting messages
