### PR TITLE
Change sending message area to ARS instead of geocode (DEV-134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `CNG` Send ARS instead of a geocode to Kafka
 - `CNG` Structure of administrative areas is changed to ARS (from AGS)
 - `ADD` Mail support for registration, password reset, email change is available
 - `CNG` Update dependencies

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -29,8 +29,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
         identifier: event.message_id,
         headline: event.title,
         description: event.body,
-        geocode:
-          "POLYGON ((11.795583 51.385388, 11.813135 51.398215, 11.827426 51.396073, 11.823821 51.391842, 11.795583 51.385388))",
+        ars: "059580004004",
         published_at: NaiveDateTime.to_iso8601(metadata.created_at)
       }
       |> Jason.encode!()


### PR DESCRIPTION
This PR changes sending location data to ARS instead of the geocode when publishing message to Kafka.

Relates to DEV-134

### Todos

- [x] Change message payload
- [ ] Add tests
- [ ] Update translations
- [x] Update changelog
- [ ] Check environment variables for dev deployment
