### PR TITLE
Fix handling login attempt with unconfirmed account (DEV-149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `FIX` Login with unconfirmed users issues a note
 - `ADD` Setup GH Actions to deploy application to AWS
 - `CNG` Send ARS instead of a geocode to Kafka
 - `CNG` Structure of administrative areas is changed to ARS (from AGS)

--- a/lib/dealog_backoffice/accounts.ex
+++ b/lib/dealog_backoffice/accounts.ex
@@ -31,6 +31,9 @@ defmodule DealogBackoffice.Accounts do
   @doc """
   Gets a user by email and password.
 
+  If the user is not yet confirmed they will be treated as with invalid
+  credentials to avoid tampering.
+
   ## Examples
 
       iex> get_user_by_email_and_password("foo@example.com", "correct_password")
@@ -43,7 +46,7 @@ defmodule DealogBackoffice.Accounts do
   def get_user_by_email_and_password(email, password)
       when is_binary(email) and is_binary(password) do
     user = Repo.get_by(User, email: email)
-    if User.valid_password?(user, password), do: user
+    if User.confirmed?(user) and User.valid_password?(user, password), do: user
   end
 
   @doc """

--- a/lib/dealog_backoffice/accounts/user.ex
+++ b/lib/dealog_backoffice/accounts/user.ex
@@ -117,4 +117,10 @@ defmodule DealogBackoffice.Accounts.User do
       add_error(changeset, :current_password, "is not valid")
     end
   end
+
+  def confirmed?(user) when is_nil(user), do: false
+
+  def confirmed?(user) do
+    !is_nil(user.confirmed_at)
+  end
 end

--- a/test/dealog_backoffice/accounts_test.exs
+++ b/test/dealog_backoffice/accounts_test.exs
@@ -27,8 +27,9 @@ defmodule DealogBackoffice.AccountsTest do
       refute Accounts.get_user_by_email_and_password(user.email, "invalid")
     end
 
-    test "returns the user if the email and password are valid" do
+    test "returns the user if the user is confirmed and email and password are valid" do
       %{id: id} = user = user_fixture()
+      confirm_user(user)
 
       assert %User{id: ^id} =
                Accounts.get_user_by_email_and_password(user.email, valid_user_password())
@@ -229,7 +230,9 @@ defmodule DealogBackoffice.AccountsTest do
 
   describe "update_user_password/3" do
     setup do
-      %{user: user_fixture()}
+      user = user_fixture()
+      confirm_user(user)
+      %{user: user}
     end
 
     test "validates password", %{user: user} do
@@ -438,7 +441,9 @@ defmodule DealogBackoffice.AccountsTest do
 
   describe "reset_user_password/2" do
     setup do
-      %{user: user_fixture()}
+      user = user_fixture()
+      confirm_user(user)
+      %{user: user}
     end
 
     test "validates password", %{user: user} do

--- a/test/dealog_backoffice/accounts_test.exs
+++ b/test/dealog_backoffice/accounts_test.exs
@@ -23,13 +23,12 @@ defmodule DealogBackoffice.AccountsTest do
     end
 
     test "does not return the user if the password is not valid" do
-      user = user_fixture()
+      user = confirmed_user_fixture()
       refute Accounts.get_user_by_email_and_password(user.email, "invalid")
     end
 
     test "returns the user if the user is confirmed and email and password are valid" do
-      %{id: id} = user = user_fixture()
-      confirm_user(user)
+      %{id: id} = user = confirmed_user_fixture()
 
       assert %User{id: ^id} =
                Accounts.get_user_by_email_and_password(user.email, valid_user_password())
@@ -230,9 +229,7 @@ defmodule DealogBackoffice.AccountsTest do
 
   describe "update_user_password/3" do
     setup do
-      user = user_fixture()
-      confirm_user(user)
-      %{user: user}
+      %{user: confirmed_user_fixture()}
     end
 
     test "validates password", %{user: user} do
@@ -441,9 +438,7 @@ defmodule DealogBackoffice.AccountsTest do
 
   describe "reset_user_password/2" do
     setup do
-      user = user_fixture()
-      confirm_user(user)
-      %{user: user}
+      %{user: confirmed_user_fixture()}
     end
 
     test "validates password", %{user: user} do

--- a/test/dealog_backoffice_web/controllers/user_reset_password_controller_test.exs
+++ b/test/dealog_backoffice_web/controllers/user_reset_password_controller_test.exs
@@ -6,7 +6,9 @@ defmodule DealogBackofficeWeb.UserResetPasswordControllerTest do
   import DealogBackoffice.AccountsFixtures
 
   setup do
-    %{user: user_fixture()}
+    user = user_fixture()
+    confirm_user(user)
+    %{user: user}
   end
 
   describe "GET /users/reset_password" do

--- a/test/dealog_backoffice_web/controllers/user_reset_password_controller_test.exs
+++ b/test/dealog_backoffice_web/controllers/user_reset_password_controller_test.exs
@@ -6,9 +6,7 @@ defmodule DealogBackofficeWeb.UserResetPasswordControllerTest do
   import DealogBackoffice.AccountsFixtures
 
   setup do
-    user = user_fixture()
-    confirm_user(user)
-    %{user: user}
+    %{user: confirmed_user_fixture()}
   end
 
   describe "GET /users/reset_password" do

--- a/test/dealog_backoffice_web/controllers/user_session_controller_test.exs
+++ b/test/dealog_backoffice_web/controllers/user_session_controller_test.exs
@@ -6,9 +6,7 @@ defmodule DealogBackofficeWeb.UserSessionControllerTest do
   import DealogBackoffice.AccountsFixtures
 
   setup do
-    user = user_fixture()
-    confirm_user(user)
-    %{user: user}
+    %{user: confirmed_user_fixture()}
   end
 
   describe "GET /users/log_in" do

--- a/test/dealog_backoffice_web/controllers/user_session_controller_test.exs
+++ b/test/dealog_backoffice_web/controllers/user_session_controller_test.exs
@@ -6,7 +6,9 @@ defmodule DealogBackofficeWeb.UserSessionControllerTest do
   import DealogBackoffice.AccountsFixtures
 
   setup do
-    %{user: user_fixture()}
+    user = user_fixture()
+    confirm_user(user)
+    %{user: user}
   end
 
   describe "GET /users/log_in" do

--- a/test/support/account_test_helpers.ex
+++ b/test/support/account_test_helpers.ex
@@ -1,0 +1,54 @@
+defmodule DealogBackoffice.AccountTestHelpers do
+  @doc """
+  Setup helper that registers users.
+
+      setup :register_user
+
+  It stores an updated connection in the test context.
+  """
+  def register_user(%{conn: conn}) do
+    user = DealogBackoffice.AccountsFixtures.user_fixture()
+
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  @doc """
+  Setup helper that registers, confirms and logs in users.
+
+      setup :register_and_log_in_user
+
+  It stores an updated connection and a registered user in the
+  test context.
+  """
+  def register_and_log_in_user(%{conn: conn}) do
+    user = DealogBackoffice.AccountsFixtures.user_fixture()
+    confirm_user(user)
+
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  @doc """
+  Confirm user registration. The user is only able to login / create a session
+  once they confirmed their registration.
+  """
+  def confirm_user(user) do
+    {encoded_token, user_token} =
+      DealogBackoffice.Accounts.UserToken.build_email_token(user, "confirm")
+
+    DealogBackoffice.Repo.insert!(user_token)
+    DealogBackoffice.Accounts.confirm_user(encoded_token)
+  end
+
+  @doc """
+  Logs the given `user` into the `conn`.
+
+  It returns an updated `conn`.
+  """
+  def log_in_user(conn, user) do
+    token = DealogBackoffice.Accounts.generate_user_session_token(user)
+
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:user_token, token)
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,6 +24,7 @@ defmodule DealogBackofficeWeb.ConnCase do
       import Phoenix.ConnTest
       import DealogBackofficeWeb.ConnCase
       import DealogBackofficeWeb.LiveViewTestHelpers
+      import DealogBackoffice.AccountTestHelpers
 
       alias DealogBackofficeWeb.Router.Helpers, as: Routes
 
@@ -40,58 +41,5 @@ defmodule DealogBackofficeWeb.ConnCase do
     end
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
-  end
-
-  @doc """
-  Setup helper that registers users.
-
-      setup :register_user
-
-  It stores an updated connection in the test context.
-  """
-  def register_user(%{conn: conn}) do
-    user = DealogBackoffice.AccountsFixtures.user_fixture()
-
-    %{conn: log_in_user(conn, user), user: user}
-  end
-
-  @doc """
-  Setup helper that registers, confirms and logs in users.
-
-      setup :register_and_log_in_user
-
-  It stores an updated connection and a registered user in the
-  test context.
-  """
-  def register_and_log_in_user(%{conn: conn}) do
-    user = DealogBackoffice.AccountsFixtures.user_fixture()
-    confirm_user(user)
-
-    %{conn: log_in_user(conn, user), user: user}
-  end
-
-  @doc """
-  Confirm user registration. The user is only able to login / create a session
-  once they confirmed their registration.
-  """
-  def confirm_user(user) do
-    {encoded_token, user_token} =
-      DealogBackoffice.Accounts.UserToken.build_email_token(user, "confirm")
-
-    DealogBackoffice.Repo.insert!(user_token)
-    DealogBackoffice.Accounts.confirm_user(encoded_token)
-  end
-
-  @doc """
-  Logs the given `user` into the `conn`.
-
-  It returns an updated `conn`.
-  """
-  def log_in_user(conn, user) do
-    token = DealogBackoffice.Accounts.generate_user_session_token(user)
-
-    conn
-    |> Phoenix.ConnTest.init_test_session(%{})
-    |> Plug.Conn.put_session(:user_token, token)
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -25,6 +25,7 @@ defmodule DealogBackoffice.DataCase do
       import Ecto.Query
       import Commanded.Assertions.EventAssertions
       import DealogBackoffice.DataCase
+      import DealogBackoffice.AccountTestHelpers
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -25,7 +25,6 @@ defmodule DealogBackoffice.DataCase do
       import Ecto.Query
       import Commanded.Assertions.EventAssertions
       import DealogBackoffice.DataCase
-      import DealogBackoffice.AccountTestHelpers
     end
   end
 

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -19,6 +19,13 @@ defmodule DealogBackoffice.AccountsFixtures do
     user
   end
 
+  def confirmed_user_fixture(attrs \\ %{}) do
+    user = user_fixture(attrs)
+    DealogBackoffice.AccountTestHelpers.confirm_user(user)
+
+    user
+  end
+
   def extract_user_token(fun) do
     {:ok, captured} = fun.(&"[TOKEN]#{&1}[TOKEN]")
     [_, token, _] = String.split(captured.text_body, "[TOKEN]")


### PR DESCRIPTION
This PR fixes a redirect issue if trying to log in with an unconfirmed account.

Relates to DEV-149

### Todos

- [x] Require confirmed user on login
- [x] Add tests
- [x] Update changelog
