### PR TITLE
Remove deprecated command from GH Actions (DEV-170)

### DIFF
--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: DEalog/version-action@v0.1.0
         with:
           fallback-prefix: "1.0.0-SNAPSHOT-"
-      
+
       - name: Create artifact
         uses: actions/upload-artifact@v2
         with:
@@ -96,10 +96,10 @@ jobs:
 
       - name: Compile and release application
         run: mix do compile, release
-      
+
       - name: Tar application files to keep file permissions
         run: tar -cvf app.tar ./_build/prod/rel/backoffice ./rel/run.sh
-      
+
       - name: Create artifact
         uses: actions/upload-artifact@v2
         with:
@@ -109,7 +109,7 @@ jobs:
             ./CHANGELOG.md
             ./.github/Dockerfile
           if-no-files-found: error
-  
+
   test:
     runs-on: ubuntu-latest
     name: Test Elixir project
@@ -125,7 +125,7 @@ jobs:
     services:
       db:
         image: postgres:12.1-alpine
-        ports: [ "5432:5432" ]
+        ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -166,27 +166,27 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Dockerize and publish
-    needs: [ version, build, test ]
+    needs: [version, build, test]
 
     steps:
       - name: Fetch version artifact
         uses: actions/download-artifact@v2
         with:
           name: version
-      
+
       - name: Fetch build artifact
         uses: actions/download-artifact@v2
         with:
           name: backoffice
-      
+
       - name: Untar application files
         run: tar -xvf app.tar .
 
       - name: Set env
         run: |
-          echo ::set-env name=VERSION::$(cat ./version.txt)
-          echo ::set-env name=IMAGE_REPO::backoffice
-          echo ::set-env name=AWS_REGION::eu-central-1
+          echo "{VERSION}={$(cat ./version.txt)}" >> ${GITHUB_ENV}
+          echo "{IMAGE_REPO}={backoffice}" >> ${GITHUB_ENV}
+          echo "{AWS_REGION}={eu-central-1}" >> ${GITHUB_ENV}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -209,7 +209,7 @@ jobs:
           image_tag: ${{ env.VERSION }}
           registry: ${{ steps.login-ecr.outputs.registry }}
           dockerfile: ./.github/Dockerfile
-      
+
       - name: Store docker image name
         run: echo ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }} >> ./full_image_name.txt
 

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -168,6 +168,10 @@ jobs:
     name: Dockerize and publish
     needs: [version, build, test]
 
+    env:
+      AWS_REGION: eu-central-1
+      IMAGE_REPO: backoffice
+
     steps:
       - name: Fetch version artifact
         uses: actions/download-artifact@v2
@@ -184,9 +188,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "{VERSION}={$(cat ./version.txt)}" >> ${GITHUB_ENV}
-          echo "{IMAGE_REPO}={backoffice}" >> ${GITHUB_ENV}
-          echo "{AWS_REGION}={eu-central-1}" >> ${GITHUB_ENV}
+          echo "VERSION=$(cat ./version.txt)" >> ${GITHUB_ENV}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to Amazon ECS
 
+    env:
+      AWS_REGION: eu-central-1
+      CLUSTER_NAME: dealog-dev
+      SERVICE_NAME: backoffice
+      CONTAINER_NAME: backoffice
+
     steps:
       - name: Download build artifacts
         uses: dawidd6/action-download-artifact@v2
@@ -21,10 +27,6 @@ jobs:
 
       - name: Set env
         run: |
-          echo "{AWS_REGION}={eu-central-1}" >> ${GITHUB_ENV}
-          echo "{CLUSTER_NAME}={dealog-dev}" >> ${GITHUB_ENV}
-          echo "{SERVICE_NAME}={backoffice}" >> ${GITHUB_ENV}
-          echo "{CONTAINER_NAME}={backoffice}" >> ${GITHUB_ENV}
           echo "{FULL_IMAGE_NAME}={$(cat ./dockerized-backoffice/full_image_name.txt)}" >> ${GITHUB_ENV}
           echo "{IMAGE_TAG}={$(cat ./version/version.txt)}" >> ${GITHUB_ENV}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
-
 name: Deploy
 
 on:
   workflow_run:
-    workflows: [ Build ]
+    workflows: [Build]
     branches:
       - main
     types:
@@ -15,46 +14,46 @@ jobs:
     name: Deploy to Amazon ECS
 
     steps:
-    - name: Download build artifacts
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: ${{ github.event.workflow_run.workflow_id }}
+      - name: Download build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
 
-    - name: Set env
-      run: |
-        echo ::set-env name=AWS_REGION::eu-central-1
-        echo ::set-env name=CLUSTER_NAME::dealog-dev
-        echo ::set-env name=SERVICE_NAME::backoffice
-        echo ::set-env name=CONTAINER_NAME::backoffice
-        echo ::set-env name=FULL_IMAGE_NAME::$(cat ./dockerized-backoffice/full_image_name.txt)
-        echo ::set-env name=IMAGE_TAG::$(cat ./version/version.txt)
-    
-    - name: Set production env
-      if: github.ref == 'refs/heads/main'
-      run: echo ::set-env name=CLUSTER_NAME::dealog-dev
-    
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
-      
-    - name: Download task definition
-      run: aws ecs describe-task-definition --task-definition ${{ env.SERVICE_NAME }} --query taskDefinition > task-definition.json
+      - name: Set env
+        run: |
+          echo "{AWS_REGION}={eu-central-1}" >> ${GITHUB_ENV}
+          echo "{CLUSTER_NAME}={dealog-dev}" >> ${GITHUB_ENV}
+          echo "{SERVICE_NAME}={backoffice}" >> ${GITHUB_ENV}
+          echo "{CONTAINER_NAME}={backoffice}" >> ${GITHUB_ENV}
+          echo "{FULL_IMAGE_NAME}={$(cat ./dockerized-backoffice/full_image_name.txt)}" >> ${GITHUB_ENV}
+          echo "{IMAGE_TAG}={$(cat ./version/version.txt)}" >> ${GITHUB_ENV}
 
-    - name: Fill in the new image ID in the Amazon ECS task definition
-      id: task-def-update
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: ./task-definition.json
-        container-name: ${{ env.CONTAINER_NAME }}
-        image: ${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+      - name: Set production env
+        if: github.ref == 'refs/heads/main'
+        run: echo "{CLUSTER_NAME}={dealog-dev}" >> ${GITHUB_ENV}
 
-    - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def-update.outputs.task-definition }}
-        service: ${{ env.SERVICE_NAME }}
-        cluster: ${{ env.CLUSTER_NAME }}
-        wait-for-service-stability: true
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download task definition
+        run: aws ecs describe-task-definition --task-definition ${{ env.SERVICE_NAME }} --query taskDefinition > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def-update
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ./task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def-update.outputs.task-definition }}
+          service: ${{ env.SERVICE_NAME }}
+          cluster: ${{ env.CLUSTER_NAME }}
+          wait-for-service-stability: true


### PR DESCRIPTION
Fix the deprecation message for:

```
Error: The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Relates to DEV-170
