### PR TITLE
Fix Kafka message payload for publishing (DEV-176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `FIX` Message payload is now compatible with the Message Service
 - `FIX` Project information (readme) can be viewed on released instances
 - `ADD` Users are anonymously tracked to get some metrics
 - `ADD` User accounts can be changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `ADD` Messages that already have been published are detected as updated ones
 - `FIX` Message payload is now compatible with the Message Service
 - `FIX` Project information (readme) can be viewed on released instances
 - `ADD` Users are anonymously tracked to get some metrics

--- a/lib/dealog_backoffice/messages/events/message_updated.ex
+++ b/lib/dealog_backoffice/messages/events/message_updated.ex
@@ -1,0 +1,9 @@
+defmodule DealogBackoffice.Messages.Events.MessageUpdated do
+  @derive Jason.Encoder
+  defstruct [
+    :message_id,
+    :status,
+    :title,
+    :body
+  ]
+end

--- a/lib/dealog_backoffice/messages/projectors/message.ex
+++ b/lib/dealog_backoffice/messages/projectors/message.ex
@@ -11,7 +11,8 @@ defmodule DealogBackoffice.Messages.Projectors.Message do
     MessageDeleted,
     MessageApproved,
     MessageRejected,
-    MessagePublished
+    MessagePublished,
+    MessageUpdated
   }
 
   alias DealogBackoffice.Messages.Projections.Message
@@ -70,6 +71,13 @@ defmodule DealogBackoffice.Messages.Projectors.Message do
   project(%MessagePublished{} = published, metadata, fn multi ->
     update_message(multi, published.message_id,
       status: published.status,
+      updated_at: metadata.created_at
+    )
+  end)
+
+  project(%MessageUpdated{} = updated, metadata, fn multi ->
+    update_message(multi, updated.message_id,
+      status: updated.status,
       updated_at: metadata.created_at
     )
   end)

--- a/lib/dealog_backoffice/messages/projectors/message_approval.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_approval.ex
@@ -8,7 +8,8 @@ defmodule DealogBackoffice.Messages.Projectors.MessageApproval do
     MessageSentForApproval,
     MessageApproved,
     MessageRejected,
-    MessagePublished
+    MessagePublished,
+    MessageUpdated
   }
 
   alias DealogBackoffice.Messages.Projections.MessageForApproval
@@ -43,6 +44,10 @@ defmodule DealogBackoffice.Messages.Projectors.MessageApproval do
 
   project(%MessagePublished{} = published, fn multi ->
     Ecto.Multi.delete_all(multi, :remove_published_message, query(published.message_id))
+  end)
+
+  project(%MessageUpdated{} = updated, fn multi ->
+    Ecto.Multi.delete_all(multi, :remove_updated_message, query(updated.message_id))
   end)
 
   defp update_message_approval(multi, message_id, changes) do

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -6,13 +6,21 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
   @topic "messages"
   @worker_name :kafka_ex
 
-  alias DealogBackoffice.Messages.Events.MessagePublished
+  alias DealogBackoffice.Messages.Events.{MessagePublished, MessageUpdated}
   alias KafkaEx.Protocol.Produce.Message, as: KafkaMessage
   alias KafkaEx.Protocol.Produce.Request
 
   def handle(%MessagePublished{} = event, metadata) do
+    produce_and_send_message("Published", event, metadata)
+  end
+
+  def handle(%MessageUpdated{} = event, metadata) do
+    produce_and_send_message("Updated", event, metadata)
+  end
+
+  defp produce_and_send_message(type, event, metadata) do
     ensure_connected()
-    messages = build_messages(event, metadata)
+    messages = build_messages(type, event, metadata)
     request = %Request{topic: @topic, api_version: 3, messages: messages}
     KafkaEx.produce(request)
   end
@@ -21,16 +29,19 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
     KafkaEx.create_worker(@worker_name)
   end
 
-  defp build_messages(event, metadata), do: List.wrap(build_message(event, metadata))
+  defp build_messages(type, event, metadata), do: List.wrap(build_message(type, event, metadata))
 
-  defp build_message(event, metadata) do
+  defp build_message(type, event, metadata) do
     payload =
       %{
-        identifier: event.message_id,
-        headline: event.title,
-        description: event.body,
-        ars: "059580004004",
-        published_at: NaiveDateTime.to_iso8601(metadata.created_at)
+        type: type,
+        payload: %{
+          identifier: event.message_id,
+          headline: event.title,
+          description: event.body,
+          ars: "059580004004",
+          published_at: NaiveDateTime.to_iso8601(metadata.created_at)
+        }
       }
       |> Jason.encode!()
 


### PR DESCRIPTION
This PR fixes the payload of Kafka messages to be en par with the expected structure of the Message Service.

Further the system now differentiates between published (first time) and updated DEalog messages.

Relates to DEV-176

### Todos

- [x] Fix the payload
- [x] Add differentiation between first time and follow up published messages
- [x] Add tests
- [x] Update changelog
- [x] Check environment variables for dev deployment
