### PR TITLE
Fix type name for published messages (DEV-176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `FIX` Type of first time published messages is changed to `Created`
 - `ADD` Messages that already have been published are detected as updated ones
 - `FIX` Message payload is now compatible with the Message Service
 - `FIX` Project information (readme) can be viewed on released instances

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -11,7 +11,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
   alias KafkaEx.Protocol.Produce.Request
 
   def handle(%MessagePublished{} = event, metadata) do
-    produce_and_send_message("Published", event, metadata)
+    produce_and_send_message("Created", event, metadata)
   end
 
   def handle(%MessageUpdated{} = event, metadata) do


### PR DESCRIPTION
This PR fixes the name of a newly published message from `Published` to `Created`.

Relates to DEV-176

### Todos

- [x] Fix the name
- [x] Update changelog
