### PR TITLE
Change published date to timestamp (DEV-176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `FIX` Publish at is sent as a timestamp instead of a ISO 8601 string
 - `FIX` Type of first time published messages is changed to `Created`
 - `ADD` Messages that already have been published are detected as updated ones
 - `FIX` Message payload is now compatible with the Message Service

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -40,7 +40,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
           headline: event.title,
           description: event.body,
           ars: "059580004004",
-          published_at: NaiveDateTime.to_iso8601(metadata.created_at)
+          publishedAt: DateTime.to_unix(metadata.created_at, :millisecond)
         }
       }
       |> Jason.encode!()


### PR DESCRIPTION
The PR changes the published date to a timestamp.

Relates to DEV-176

### Todos

- [x] Change format
- [x] Update changelog
