### PR TITLE
Add organization and ars to published messages (DEV-182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `ADD` The organization of the message being published is added (hard coded at the moment)
+- `ADD` The ars code of the message being published is added (hard coded at the moment)
 - `ADD` A super user can be created if email and password is supplied
 - `ADD` Publishing of messsages to Kafka is logged
 - `ADD` All command dispatches are logged

--- a/lib/dealog_backoffice/messages/projections/published_messages.ex
+++ b/lib/dealog_backoffice/messages/projections/published_messages.ex
@@ -9,6 +9,8 @@ defmodule DealogBackoffice.Messages.Projections.PublishedMessage do
   schema "published_messages" do
     field :title, :string
     field :body, :string
+    field :ars, :string
+    field :organization, :string
     field :status, Status
 
     timestamps()

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -47,6 +47,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
           headline: event.title,
           description: event.body,
           ars: "059580004004",
+          organization: "DEalog Team",
           publishedAt: DateTime.to_unix(metadata.created_at, :millisecond)
         }
       }

--- a/lib/dealog_backoffice/messages/projectors/published_message.ex
+++ b/lib/dealog_backoffice/messages/projectors/published_message.ex
@@ -15,6 +15,8 @@ defmodule DealogBackoffice.Messages.Projectors.PublishedMessage do
         id: published.message_id,
         title: published.title,
         body: published.body,
+        ars: "059580004004",
+        organization: "DEalog Team",
         status: published.status,
         inserted_at: metadata.created_at
       }
@@ -25,6 +27,8 @@ defmodule DealogBackoffice.Messages.Projectors.PublishedMessage do
     changes = [
       title: updated.title,
       body: updated.body,
+      ars: "059580004004",
+      organization: "DEalog Team",
       status: updated.status,
       updated_at: metadata.created_at
     ]

--- a/priv/repo/migrations/20201118170035_add_ars_and_organization_to_published_message_projection.exs
+++ b/priv/repo/migrations/20201118170035_add_ars_and_organization_to_published_message_projection.exs
@@ -1,0 +1,11 @@
+defmodule DealogBackoffice.Repo.Migrations.AddArsAndOrganizationToPublishedMessageProjection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:published_messages) do
+      add :ars, :string
+      add :organization, :string
+    end
+    create index(:published_messages, [:ars])
+  end
+end


### PR DESCRIPTION
This PR adds the field `organization` to the payload for remotely (Kafka) published messages.

> This is hard coded to "DEalog Team" until integrated in the message aggregate itself.

Further the local projection also has the `organization` field reflected as well as the missing `ars` code field.

Relates to DEV-182

### Todos

- [x] Add field to payload of the Message Service projector
- [x] Add fields to the local projector
- [x] Update changelog
