### PR TITLE
Add category to published messages (DEV-184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `ADD` The category of the message being published is added (hard coded at the moment)
 - `ADD` The organization of the message being published is added (hard coded at the moment)
 - `ADD` The ars code of the message being published is added (hard coded at the moment)
 - `ADD` A super user can be created if email and password is supplied

--- a/lib/dealog_backoffice/messages/projections/published_messages.ex
+++ b/lib/dealog_backoffice/messages/projections/published_messages.ex
@@ -9,6 +9,7 @@ defmodule DealogBackoffice.Messages.Projections.PublishedMessage do
   schema "published_messages" do
     field :title, :string
     field :body, :string
+    field :category, :string
     field :ars, :string
     field :organization, :string
     field :status, Status

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -46,6 +46,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
           identifier: event.message_id,
           headline: event.title,
           description: event.body,
+          category: "Other",
           ars: "059580004004",
           organization: "DEalog Team",
           publishedAt: DateTime.to_unix(metadata.created_at, :millisecond)

--- a/lib/dealog_backoffice/messages/projectors/published_message.ex
+++ b/lib/dealog_backoffice/messages/projectors/published_message.ex
@@ -15,6 +15,7 @@ defmodule DealogBackoffice.Messages.Projectors.PublishedMessage do
         id: published.message_id,
         title: published.title,
         body: published.body,
+        category: "Other",
         ars: "059580004004",
         organization: "DEalog Team",
         status: published.status,
@@ -27,6 +28,7 @@ defmodule DealogBackoffice.Messages.Projectors.PublishedMessage do
     changes = [
       title: updated.title,
       body: updated.body,
+      category: "Other",
       ars: "059580004004",
       organization: "DEalog Team",
       status: updated.status,

--- a/priv/repo/migrations/20201118201429_add_category_to_published_message_projection.exs
+++ b/priv/repo/migrations/20201118201429_add_category_to_published_message_projection.exs
@@ -1,0 +1,9 @@
+defmodule DealogBackoffice.Repo.Migrations.AddCategoryToPublishedMessageProjection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:published_messages) do
+      add :category, :string
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the field `category` to published messages sent to the Message Service (Kafka) and being projected locally. The value currently is hard coded to `Other`.

Relates to DEV-184

### Todos

- [x] Add field to projection for Kafka
- [x] Add field to local projection
- [x] Update changelog
