### PR TITLE
Add banner for incomplete accounts (DEV-206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `ADD` All message actions are disabled when the account is incomplete
+- `ADD` User gets a warning when account is not setup
 - `ADD` Author and organization meta data is saved for all message related events
 - `ADD` Check origin config for websocket connections is introduced
 - `CNG` Move hostname config to release

--- a/lib/dealog_backoffice/messages/projections/message_change.ex
+++ b/lib/dealog_backoffice/messages/projections/message_change.ex
@@ -1,7 +1,7 @@
 defmodule DealogBackoffice.Messages.Projections.MessageChange do
   use Ecto.Schema
 
-  alias DealogBackoffice.Messages.Projections.{Message, MessageForApproval}
+  alias DealogBackoffice.Messages.Projections.Message
 
   @primary_key {:id, :binary_id, autogenerate: false}
   @timestamps_opts [type: :utc_datetime_usec]

--- a/lib/dealog_backoffice_web.ex
+++ b/lib/dealog_backoffice_web.ex
@@ -95,6 +95,7 @@ defmodule DealogBackofficeWeb do
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View
 
+      import DealogBackofficeWeb.AuthHelpers
       import DealogBackofficeWeb.DateHelpers
       import DealogBackofficeWeb.ErrorHelpers
       import DealogBackofficeWeb.FeedbackHelpers

--- a/lib/dealog_backoffice_web/live/components/incomplete_account_banner.ex
+++ b/lib/dealog_backoffice_web/live/components/incomplete_account_banner.ex
@@ -1,0 +1,3 @@
+defmodule DealogBackofficeWeb.Components.IncompleteAccountBanner do
+  use DealogBackofficeWeb, :live_component
+end

--- a/lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex
+++ b/lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex
@@ -1,0 +1,22 @@
+<div class="relative bg-yellow-600">
+  <div class="px-3 py-3 mx-auto max-w-screen-xl sm:px-6 lg:px-8">
+    <div class="text-center sm:px-12">
+      <p class="font-medium text-white">
+        <span class="md:hidden">
+          <%= gettext "Please setup your account in order to use DEalog." %>
+        </span>
+        <span class="hidden md:inline">
+          <%= gettext "The account is not onboarded. Please setup your account in order to use DEalog." %>
+        </span>
+        <span class="inline-block ml-2">
+          <%=
+            live_redirect to: Routes.settings_path(@socket, :new, @current_user),
+              class: "font-bold text-white underline"
+          do %>
+            <%= gettext "Onboard" %> &rarr;
+          <% end %>
+        </span>
+      </p>
+    </div>
+  </div>
+</div>

--- a/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
+++ b/lib/dealog_backoffice_web/live/message_approvals/show.html.leex
@@ -146,7 +146,7 @@
               <%= gettext "Back to overview" %>
             </a>
           </div>
-          <%= if @message.status == :waiting_for_approval do %>
+          <%= if is_account_complete?(@current_user) and @message.status == :waiting_for_approval do %>
             <div>
               <a
                 href="<%= Routes.approvals_path(@socket, :approve, @message) %>"
@@ -155,7 +155,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.status == :waiting_for_approval do %>
+          <%= if is_account_complete?(@current_user) and @message.status == :waiting_for_approval do %>
             <div>
               <a
                 href="<%= Routes.approvals_path(@socket, :reject, @message) %>"
@@ -164,7 +164,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.status == :approved do %>
+          <%= if is_account_complete?(@current_user) and @message.status == :approved do %>
             <div>
               <a
                 href="<%= Routes.approvals_path(@socket, :publish, @message) %>"

--- a/lib/dealog_backoffice_web/live/navigation_component.html.leex
+++ b/lib/dealog_backoffice_web/live/navigation_component.html.leex
@@ -75,7 +75,7 @@
           %>
           <!-- Profile dropdown -->
           <div
-            class="relative ml-3"
+            class="relative z-10 ml-3"
             x-data="{ isProfileOpen: false }"
           >
             <div>

--- a/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
+++ b/lib/dealog_backoffice_web/live/organization_messages/show.html.leex
@@ -121,7 +121,7 @@
               <dd class="mt-1 text-sm text-gray-900 leading-5 sm:mt-0 sm:col-span-2">
                 <ul class="border border-gray-200 rounded-md">
                   <%= for change <- @message.changes do %>
-                    <%= 
+                    <%=
                       live_component @socket,
                         DealogBackofficeWeb.Components.ChangeEntryComponent,
                         change: change
@@ -146,7 +146,7 @@
               <%= gettext "Back to overview" %>
             </a>
           </div>
-          <%= if @message.published and @message.status in [:draft] do %>
+          <%= if is_account_complete?(@current_user) and @message.published and @message.status in [:draft] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :discard_change, @message) %>"
@@ -155,7 +155,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.published and @message.status in [:published] do %>
+          <%= if is_account_complete?(@current_user) and @message.published and @message.status in [:published] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :archive, @message) %>"
@@ -164,7 +164,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.published and @message.status in [:draft] do %>
+          <%= if is_account_complete?(@current_user) and @message.published and @message.status in [:draft] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :discard_change_and_archive, @message) %>"
@@ -173,7 +173,7 @@
               </a>
             </div>
           <% end %>
-          <%= unless @message.status in [:waiting_for_approval] do %>
+          <%= unless is_account_incomplete?(@current_user) or @message.status in [:waiting_for_approval] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :change, @message) %>"
@@ -182,7 +182,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.status in [:draft] do %>
+          <%= if is_account_complete?(@current_user) and @message.status in [:draft] do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :send_for_approval, @message) %>"
@@ -191,7 +191,7 @@
               </a>
             </div>
           <% end %>
-          <%= if @message.status in [:draft] and !@message.published do %>
+          <%= if is_account_complete?(@current_user) and @message.status in [:draft] and !@message.published do %>
             <div>
               <a
                 href="<%= Routes.organization_messages_path(@socket, :delete, @message) %>"

--- a/lib/dealog_backoffice_web/live/settings/index.html.leex
+++ b/lib/dealog_backoffice_web/live/settings/index.html.leex
@@ -144,13 +144,13 @@
                       <div class="mt-2">
                         <%= if account_status == :new do %>
                           <%=
-                            link gettext("Onboard"),
+                            live_redirect gettext("Onboard"),
                               to: Routes.settings_path(@socket, :new, user),
                               class: "text-yellow-400 hover:text-yellow-600"
                           %>
                         <% else %>
                           <%=
-                            link gettext("Edit"),
+                            live_redirect gettext("Edit"),
                               to: Routes.settings_path(@socket, :change, user.account),
                               class: "text-yellow-400 hover:text-yellow-600"
                           %>

--- a/lib/dealog_backoffice_web/templates/layout/live.html.leex
+++ b/lib/dealog_backoffice_web/templates/layout/live.html.leex
@@ -7,6 +7,15 @@
   %>
 </header>
 <main role="main" class="px-4 pt-4 pb-48 sm:pb:24">
+  <%= if is_account_incomplete?(@current_user) do %>
+    <div class="mb-2 -mx-4 -mt-2">
+      <%=
+        live_component @socket,
+          DealogBackofficeWeb.Components.IncompleteAccountBanner,
+          current_user: @current_user
+      %>
+    </div>
+  <% end %>
   <%= if has_success_flash?(@flash) do %>
     <div class="alert alert-info" role="alert"
       phx-value-key="info"

--- a/lib/dealog_backoffice_web/views/auth_helpers.ex
+++ b/lib/dealog_backoffice_web/views/auth_helpers.ex
@@ -1,0 +1,11 @@
+defmodule DealogBackofficeWeb.AuthHelpers do
+  @moduledoc """
+  Helpers for account related functions.
+  """
+
+  def is_account_complete?(%DealogBackoffice.Accounts.User{account: nil}), do: false
+  def is_account_complete?(_), do: false
+
+  def is_account_incomplete?(%DealogBackoffice.Accounts.User{account: nil}), do: true
+  def is_account_incomplete?(_), do: false
+end

--- a/priv/translations/web/de/LC_MESSAGES/default.po
+++ b/priv/translations/web/de/LC_MESSAGES/default.po
@@ -488,8 +488,8 @@ msgid "Message %{title} is in review an cannot be changed"
 msgstr "Die Meldung %{title} ist in Prüfung und kann momentan nicht geändert werden"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:18
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:33
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:27
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:42
 msgid "Successfully performed action!"
 msgstr "Aktion erfolgreich durchgeführt!"
 
@@ -499,8 +499,8 @@ msgid "Save message"
 msgstr "Meldung speichern"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:47
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:61
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:56
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:70
 msgid "There was an error!"
 msgstr "Ein Fehler ist aufgetreten!"
 
@@ -510,7 +510,7 @@ msgid "Add a note of why the message is rejected. This message will be shown to 
 msgstr "Bitte einen Hinweis, warum die Meldung zurückgewiesen wurde. Dieser wird der bearbeitenden Person angezeigt werden."
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:45
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:46
 msgid "Message %{title} rejected"
 msgstr "Meldung %{title} erfolgreich erstellt"
 
@@ -530,7 +530,7 @@ msgid "Reject message"
 msgstr "Meldung zurückweisen"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:188
+#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:142
 #: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:146 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:146
 msgid "Back to overview"
 msgstr "Zurück zur Übersicht"
@@ -562,8 +562,8 @@ msgstr "Zuletzt geändert um"
 #, elixir-format
 #: lib/dealog_backoffice_web/live/all_messages/show.ex:30
 #: lib/dealog_backoffice_web/live/message_approvals/edit.ex:55 lib/dealog_backoffice_web/live/message_approvals/show.ex:30
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:93 lib/dealog_backoffice_web/live/organization_messages/edit.ex:125
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:165 lib/dealog_backoffice_web/live/organization_messages/edit.ex:199
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:93 lib/dealog_backoffice_web/live/organization_messages/edit.ex:127
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:169 lib/dealog_backoffice_web/live/organization_messages/edit.ex:205
 #: lib/dealog_backoffice_web/live/organization_messages/show.ex:30
 msgid "Message %{id} could not be found"
 msgstr "Meldung %{id} konnte nicht gefunden werden"
@@ -587,7 +587,7 @@ msgid "Message information"
 msgstr "Meldungsinformationen"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:75
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:84
 msgid "Message not found!"
 msgstr "Meldung nicht gefunden!"
 
@@ -598,9 +598,7 @@ msgid "Message status"
 msgstr "Meldungsstatus"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:129
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:142 lib/dealog_backoffice_web/live/all_messages/show.html.leex:155
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:169 lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:72
+#: lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:72
 msgid "by"
 msgstr "von"
 
@@ -666,12 +664,12 @@ msgid "Message %{title} successfully deleted"
 msgstr "Meldung %{title} erfolgreich gelöscht"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:69
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:71
 msgid "Message %{title} has to be in status approved in order to be published"
 msgstr "Die Meldung %{title} muss sich im Zustand freigegeben befinden, um veröffentlicht werden zu können"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:79
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:81
 msgid "Message %{title} successfully published"
 msgstr "Meldung %{title} erfolgreich veröffentlicht"
 
@@ -970,7 +968,7 @@ msgid "New user"
 msgstr "Neuer Benutzer"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/settings/index.html.leex:147
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:16 lib/dealog_backoffice_web/live/settings/index.html.leex:147
 msgid "Onboard"
 msgstr "Einrichten"
 
@@ -1080,7 +1078,7 @@ msgid "Archive"
 msgstr "Archivieren"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:155
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:159
 msgid "Changes for message %{id} could not be discarded"
 msgstr "Änderungen für Meldung %{id} konnten nicht zurückgesetzt werden"
 
@@ -1095,27 +1093,27 @@ msgid "Discard unpublished changes and archive"
 msgstr "Unveröffentlichte Änderungen verwerfen und archivieren"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:115
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:117
 msgid "Message %{id} could not be archived"
 msgstr "Meldung %{id} konnte nicht archiviert werden"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:189
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:195
 msgid "Message %{id} could not be reverted and archived"
 msgstr "Meldung %{id} konnte nicht zurückgesetzt und archiviert werden"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:147
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:151
 msgid "Message %{title} reverted to published version"
 msgstr "Meldung %{title} zum veröffentlichten Stand zurückgesetzt"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:179
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:185
 msgid "Message %{title} reverted to published version and archived"
 msgstr "Meldung %{title} zum veröffentlichten Stand zurückgesetzt und archiviert"
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:135
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:137
 msgid "Message %{title} successfully archived"
 msgstr "Meldung %{title} erfolgreich archiviert"
 
@@ -1153,3 +1151,13 @@ msgstr "Zurückgewiesen"
 #: lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:20
 msgid "Sent for approval"
 msgstr "Zur Freigabe geschickt"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:6
+msgid "Please setup your account in order to use DEalog."
+msgstr "Bitte richten Sie ein Benutzerkonto ein um DEalog nutzen zu können."
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:9
+msgid "The account is not onboarded. Please setup your account in order to use DEalog."
+msgstr "Das Benutzerkonto ist nicht eingerichtet. Bitte richten Sie das Konto ein um DEalog nutzen zu können."

--- a/priv/translations/web/default.pot
+++ b/priv/translations/web/default.pot
@@ -487,8 +487,8 @@ msgid "Message %{title} is in review an cannot be changed"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:18
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:33
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:27
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:42
 msgid "Successfully performed action!"
 msgstr ""
 
@@ -498,8 +498,8 @@ msgid "Save message"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:47
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:61
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:56
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:70
 msgid "There was an error!"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgid "Add a note of why the message is rejected. This message will be shown to 
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:45
+#: lib/dealog_backoffice_web/live/message_approvals/form_component.ex:46
 msgid "Message %{title} rejected"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgid "Reject message"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:188
+#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:142
 #: lib/dealog_backoffice_web/live/message_approvals/show.html.leex:146 lib/dealog_backoffice_web/live/organization_messages/show.html.leex:146
 msgid "Back to overview"
 msgstr ""
@@ -561,8 +561,8 @@ msgstr ""
 #, elixir-format
 #: lib/dealog_backoffice_web/live/all_messages/show.ex:30
 #: lib/dealog_backoffice_web/live/message_approvals/edit.ex:55 lib/dealog_backoffice_web/live/message_approvals/show.ex:30
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:93 lib/dealog_backoffice_web/live/organization_messages/edit.ex:125
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:165 lib/dealog_backoffice_web/live/organization_messages/edit.ex:199
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:93 lib/dealog_backoffice_web/live/organization_messages/edit.ex:127
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:169 lib/dealog_backoffice_web/live/organization_messages/edit.ex:205
 #: lib/dealog_backoffice_web/live/organization_messages/show.ex:30
 msgid "Message %{id} could not be found"
 msgstr ""
@@ -586,7 +586,7 @@ msgid "Message information"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/templates/layout/live.html.leex:75
+#: lib/dealog_backoffice_web/templates/layout/live.html.leex:84
 msgid "Message not found!"
 msgstr ""
 
@@ -597,9 +597,7 @@ msgid "Message status"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:129
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:142 lib/dealog_backoffice_web/live/all_messages/show.html.leex:155
-#: lib/dealog_backoffice_web/live/all_messages/show.html.leex:169 lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:72
+#: lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:72
 msgid "by"
 msgstr ""
 
@@ -665,12 +663,12 @@ msgid "Message %{title} successfully deleted"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:69
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:71
 msgid "Message %{title} has to be in status approved in order to be published"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:79
+#: lib/dealog_backoffice_web/live/message_approvals/edit.ex:81
 msgid "Message %{title} successfully published"
 msgstr ""
 
@@ -969,7 +967,7 @@ msgid "New user"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/settings/index.html.leex:147
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:16 lib/dealog_backoffice_web/live/settings/index.html.leex:147
 msgid "Onboard"
 msgstr ""
 
@@ -1079,7 +1077,7 @@ msgid "Archive"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:155
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:159
 msgid "Changes for message %{id} could not be discarded"
 msgstr ""
 
@@ -1094,27 +1092,27 @@ msgid "Discard unpublished changes and archive"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:115
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:117
 msgid "Message %{id} could not be archived"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:189
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:195
 msgid "Message %{id} could not be reverted and archived"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:147
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:151
 msgid "Message %{title} reverted to published version"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:179
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:185
 msgid "Message %{title} reverted to published version and archived"
 msgstr ""
 
 #, elixir-format
-#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:135
+#: lib/dealog_backoffice_web/live/organization_messages/edit.ex:137
 msgid "Message %{title} successfully archived"
 msgstr ""
 
@@ -1151,4 +1149,14 @@ msgstr ""
 #, elixir-format
 #: lib/dealog_backoffice_web/live/components/change_entry_component.html.leex:20
 msgid "Sent for approval"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:6
+msgid "Please setup your account in order to use DEalog."
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/live/components/incomplete_account_banner.html.leex:9
+msgid "The account is not onboarded. Please setup your account in order to use DEalog."
 msgstr ""


### PR DESCRIPTION
This PR introduces a banner that is shown for newly registered user that have not yet setup an account.

Further all actions are disabled for account-less users.

Relates to DEV-206

### Todos

- [x] Add banner if account is incomplete
- [x] Disable actions if account is incomplete
- [x] Update translations
- [x] Update changelog
