### PR TITLE
Fix Kafka projector to send ARS and org properly (DEV-211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `FIX` Fix publishing ARS and organization via Kafka
+
 ## 0.5.0
 
 This release provides the user system.

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -51,8 +51,8 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
           headline: event.title,
           description: event.body,
           category: "Other",
-          ars: get_in(metadata, ["author", "administrative_area_id"]) || "000000000000",
-          organization: get_in(metadata, ["author", "organization"]) || "DEalog System",
+          ars: get_in(metadata, ["organization", "administrative_area_id"]) || "000000000000",
+          organization: get_in(metadata, ["organization", "organization"]) || "DEalog System",
           publishedAt: DateTime.to_unix(metadata.created_at, :millisecond)
         }
       }


### PR DESCRIPTION
This PR fixes an issue with the Kafka projector not publishing the correct ARS and organization.

Relates to DEV-211
