### PR TITLE
Fix wrong path (DEV-217)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "docker"
-    directory: "./github"
+    directory: "/.github"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
This PR fixes a wrong path for Dependabot Dockerfile updates

Relates to DEV-217
