### PR TITLE
Fix sending organization with Kafka producer (DEV-221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `FIX` Organization is sent correctly to the message service
 - `NEW` Messages can have a category attached
 - `FIX` Add missing event store migration
 - `CNG` Improve preview deployments

--- a/lib/dealog_backoffice/messages/projectors/message_service.ex
+++ b/lib/dealog_backoffice/messages/projectors/message_service.ex
@@ -52,7 +52,7 @@ defmodule DealogBackoffice.Messages.Projectors.MessageService do
           description: event.body,
           category: event.category,
           ars: get_in(metadata, ["organization", "administrative_area_id"]) || "000000000000",
-          organization: get_in(metadata, ["organization", "organization"]) || "DEalog System",
+          organization: get_in(metadata, ["organization", "name"]) || "DEalog System",
           publishedAt: DateTime.to_unix(metadata.created_at, :millisecond)
         }
       }


### PR DESCRIPTION
This PR fixes an issue where always the fallback organization was published to the message service.

Relates to DEV-221
