### PR TITLE
Add link to resend confirmation (DEV-225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `NEW` The confirmation email can be resent
 - `FIX` Organization is sent correctly to the message service
 - `NEW` Messages can have a category attached
 - `FIX` Add missing event store migration

--- a/lib/dealog_backoffice_web/templates/user_registration/new.html.eex
+++ b/lib/dealog_backoffice_web/templates/user_registration/new.html.eex
@@ -85,7 +85,12 @@
         </div>
       </form>
     </div>
-    <div class="text-right">
+    <div class="flex justify-between">
+      <%=
+        link gettext("Resend confirmation mail"),
+          to: Routes.user_confirmation_path(@conn, :new),
+          class: "font-medium text-yellow-400 hover:text-yellow-300 focus:outline-none focus:underline transition ease-in-out duration-150"
+      %>
       <%=
         link gettext("Sign in"),
           to: Routes.user_session_path(@conn, :new),

--- a/priv/translations/web/de/LC_MESSAGES/default.po
+++ b/priv/translations/web/de/LC_MESSAGES/default.po
@@ -718,7 +718,7 @@ msgstr "Eingeloggt bleiben"
 
 #, elixir-format
 #: lib/dealog_backoffice_web/templates/user_confirmation/new.html.eex:43
-#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:90 lib/dealog_backoffice_web/templates/user_reset_password/edit.html.eex:94
+#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:95 lib/dealog_backoffice_web/templates/user_reset_password/edit.html.eex:94
 #: lib/dealog_backoffice_web/templates/user_reset_password/new.html.eex:47 lib/dealog_backoffice_web/templates/user_session/new.html.eex:111
 msgid "Sign in"
 msgstr "Anmelden"
@@ -1226,3 +1226,8 @@ msgstr "Rettung und Bergung"
 #: lib/dealog_backoffice_web/live/organization_messages/form_component.ex:74
 msgid "Utility, telecommunication, other non-transport infrastructure"
 msgstr "Versorgungs-, Telekommunikations- und andere Nicht-Verkehrsinfrastruktur"
+
+#, elixir-format
+#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:90
+msgid "Resend confirmation mail"
+msgstr "Bestätigungsemail erneut senden"

--- a/priv/translations/web/default.pot
+++ b/priv/translations/web/default.pot
@@ -717,7 +717,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/dealog_backoffice_web/templates/user_confirmation/new.html.eex:43
-#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:90 lib/dealog_backoffice_web/templates/user_reset_password/edit.html.eex:94
+#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:95 lib/dealog_backoffice_web/templates/user_reset_password/edit.html.eex:94
 #: lib/dealog_backoffice_web/templates/user_reset_password/new.html.eex:47 lib/dealog_backoffice_web/templates/user_session/new.html.eex:111
 msgid "Sign in"
 msgstr ""
@@ -1224,4 +1224,9 @@ msgstr ""
 #, elixir-format
 #: lib/dealog_backoffice_web/live/organization_messages/form_component.ex:74
 msgid "Utility, telecommunication, other non-transport infrastructure"
+msgstr ""
+
+#, elixir-format
+#: lib/dealog_backoffice_web/templates/user_registration/new.html.eex:90
+msgid "Resend confirmation mail"
 msgstr ""


### PR DESCRIPTION
This PR adds a resend confirmation link on the registration page

Relates to DEV-225

### Todos

- [x] Update translations
- [x] Update changelog
