### PR TITLE
Add Heilbronn to administrative areas (DEV-228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- `NEW` Add export of ARS for Heilbronn
 - `NEW` The confirmation email can be resent
 - `FIX` Organization is sent correctly to the message service
 - `NEW` Messages can have a category attached

--- a/priv/repo/administrative_areas/08.csv
+++ b/priv/repo/administrative_areas/08.csv
@@ -1,0 +1,2 @@
+ars,parent_ars,type,gen,bez
+081,08,rbz,Stuttgart,Regierungsbezirk

--- a/priv/repo/administrative_areas/081.csv
+++ b/priv/repo/administrative_areas/081.csv
@@ -1,0 +1,14 @@
+ars,parent_ars,type,gen,bez
+08117,081,krs,Göppingen,Landkreis
+08118,081,krs,Ludwigsburg,Landkreis
+08119,081,krs,Rems-Murr-Kreis,Landkreis
+08111,081,krs,Stuttgart,Stadtkreis
+08115,081,krs,Böblingen,Landkreis
+08116,081,krs,Esslingen,Landkreis
+08121,081,krs,Heilbronn,Stadtkreis
+08125,081,krs,Heilbronn,Landkreis
+08126,081,krs,Hohenlohekreis,Landkreis
+08127,081,krs,Schwäbisch Hall,Landkreis
+08128,081,krs,Main-Tauber-Kreis,Landkreis
+08135,081,krs,Heidenheim,Landkreis
+08136,081,krs,Ostalbkreis,Landkreis

--- a/priv/repo/administrative_areas/08121.csv
+++ b/priv/repo/administrative_areas/08121.csv
@@ -1,0 +1,2 @@
+ars,parent_ars,type,gen,bez
+081210000000,08121,gem,Heilbronn,Stadt


### PR DESCRIPTION
This PR add the administrative areas for Heilbronn.

Relates to DEV-228

### Todos

- [x] Add ARS for Heilbronn
- [x] Update changelog
- [x] Check environment variables for dev deployment
